### PR TITLE
fix#229, return back reload panel for Database checks

### DIFF
--- a/panellib/analyze.php
+++ b/panellib/analyze.php
@@ -72,7 +72,7 @@ function register_analyze() {
 			'level'        => PANEL_SYSTEM,
 			'refresh'      => 86400,
 			'trefresh'     => false,
-			'force'        => true,
+			'force'        => false,
 			'width'        => 'quarter-panel',
 			'priority'     => 7,
 			'alarm'        => 'green',

--- a/panellib/analyze.php
+++ b/panellib/analyze.php
@@ -72,7 +72,7 @@ function register_analyze() {
 			'level'        => PANEL_SYSTEM,
 			'refresh'      => 86400,
 			'trefresh'     => false,
-			'force'        => false,
+			'force'        => true,
 			'width'        => 'quarter-panel',
 			'priority'     => 7,
 			'alarm'        => 'green',
@@ -382,7 +382,7 @@ function analyse_db($panel, $user_id) {
 	}
 
 	if ($aerrors > 0) {
-		$panel['data'] .= '<tr><td>' . __('Aborted clients/connects: %s.  Run \'SET GLOBAL log_warnings = 1;\' from the mysql CLI and set in server.cnf to silence.', $aerrors, 'intropage') . '</td></tr>';
+		$panel['data'] .= '<tr><td>' . __('Aborted clients/connects: %s.  Run \'SET GLOBAL log_warnings = 1;\' or \' log_error_verbosity = 1;\' (depends on your MySQL/MariaDB version) from the mysql CLI and set in server.cnf to silence.', $aerrors, 'intropage') . '</td></tr>';
 
 		if ($color == 'red') {
 			$panel['alarm'] = 'red';


### PR DESCRIPTION
@TheWitness  - Is it any reason to disable reload Database checks panel? It was disable now. I sometimes use it for quick database test.