### PR TITLE
Update thold.php intropage plugin [Dev version] Last Threshold Events…

### DIFF
--- a/panellib/thold.php
+++ b/panellib/thold.php
@@ -460,6 +460,8 @@ function thold_event_detail() {
 
 		if (!$simple_perms) {
 			$q_host_cond = 'td.host_id ' . $host_cond;
+		} else {
+			$q_host_cond = "td.host_id like '%' ";
 		}
 
 		$data = db_fetch_assoc("SELECT tl.description as description,tl.time as time,

--- a/panellib/thold.php
+++ b/panellib/thold.php
@@ -451,18 +451,13 @@ function thold_event_detail() {
 		$simple_perms = get_simple_device_perms($_SESSION['sess_user_id']);
 
 		if (!$simple_perms) {
-			$allowed_devices = intropage_get_allowed_devices($_SESSION['sess_user_id']);
-			$host_cond = 'IN (' . $allowed_devices . ')';
-		} else {
-			$allowed_devices = false;
-			$q_host_cond = '';
-		}
-
-		if (!$simple_perms) {
-			$q_host_cond = 'td.host_id ' . $host_cond;
-		} else {
-			$q_host_cond = 'WHERE td.host_id ' . $host_cond;
-		}
+                       $allowed_devices = intropage_get_allowed_devices($_SESSION['sess_user_id']);
+                       $host_cond = 'IN (' . $allowed_devices . ')';
+                       $q_host_cond = 'WHERE td.host_id ' . $host_cond;
+                } else {
+                       $allowed_devices = false;
+                       $q_host_cond = '';
+                }
 
 		$data = db_fetch_assoc("SELECT tl.description as description,tl.time as time,
 			tl.status as status, uap0.user_id AS user0, uap1.user_id AS user1, uap2.user_id AS user2

--- a/panellib/thold.php
+++ b/panellib/thold.php
@@ -461,7 +461,7 @@ function thold_event_detail() {
 		if (!$simple_perms) {
 			$q_host_cond = 'td.host_id ' . $host_cond;
 		} else {
-			$q_host_cond = "td.host_id like '%' ";
+			$q_host_cond = 'WHERE td.host_id ' . $host_cond;
 		}
 
 		$data = db_fetch_assoc("SELECT tl.description as description,tl.time as time,
@@ -483,7 +483,7 @@ function thold_event_detail() {
 			ON (gl.host_id=uap1.item_id AND uap1.type=3)
 			LEFT JOIN user_auth_perms AS uap2
 			ON (gl.graph_template_id=uap2.item_id AND uap2.type=4)
-			WHERE $q_host_cond
+			$q_host_cond
 			HAVING (user0 IS NULL OR (user1 IS NULL OR user2 IS NULL))
 			ORDER BY `time` DESC
 			LIMIT 30");


### PR DESCRIPTION
…, CMDPHP ERROR: A DB Row Failed!, Error #322

intropage plugin [Dev version]

Last Threshold Events [ Updates in 5 Min ]
Click on details then the following error is logged:

2024-06-27 07:58:22 - SQL Backtrace: (
D:\cacti\apache\htdocs\cacti\plugins\intropage\intropage.php[39]:process_page_request_variables(), D:\cacti\apache\htdocs\cacti\plugins\intropage\include\functions.php[87]:intropage_detail_panel(), D:\cacti\apache\htdocs\cacti\plugins\intropage\include\functions.php[756]:thold_event_detail(), D:\cacti\apache\htdocs\cacti\plugins\intropage\panellib\thold.php[465]:db_fetch_assoc(), D:\cacti\apache\htdocs\cacti\lib\database.php[827]:db_fetch_assoc_prepared(), D:\cacti\apache\htdocs\cacti\lib\database.php[851]:db_execute_prepared() )

2024-06-27 07:58:22 - CMDPHP ERROR: A DB Row Failed!, Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'HAVING (user0 IS NULL OR (user1 IS NULL OR user2 IS NULL)) ORDER BY time DESC ' at line 1

intropage\panellib\thold.php [line#465]
		if (!$simple_perms) {
			$q_host_cond = 'td.host_id ' . $host_cond;
		} 

should be change to:
		if (!$simple_perms) {
			$q_host_cond = 'td.host_id ' . $host_cond;
		} else {
			$q_host_cond = "td.host_id like '%' ";
		}