### PR TITLE
fix(i18n): pass the intropage text domain on 51 display strings

### DIFF
--- a/display.php
+++ b/display.php
@@ -471,32 +471,32 @@ function display_information() {
 		print '<tr class="tableRow">';
 		print '<td class="textAreaNotes top left">' . __('You can Add Dashboard Panels in more ways:', 'intropage');
 		print '<ul>';
-		print '<li>' . __('Select prepared panels from the "Panels menu". Panel can be grayed out. It is due to permissions, ask administrator') . '</li>';
+		print '<li>' . __('Select prepared panels from the "Panels menu". Panel can be grayed out. It is due to permissions, ask administrator', 'intropage') . '</li>';
 		print '<li>' . __('Add any Cacti Graph, use icon', 'intropage') . '<i class="fa fa-eye"></i></li>';
-		print '<li>' . __('You can create own panels. More info in file <cacti_install_dir>/plugins/intropage/panellib/README.md') . '</li>';
+		print '<li>' . __('You can create own panels. More info in file <cacti_install_dir>/plugins/intropage/panellib/README.md', 'intropage') . '</li>';
 		print '</ul><br/>';
 		print '</td></tr>';
 
 		print '<tr class="tableRow">';
 		print '<td class="textAreaNotes top left">' . __('You can share dashboards to other users:', 'intropage');
 		print '<ul>';
-		print '<li>' . __('use "Share this dashboard" option in Actions menu - Every user can use it as template.') . '</li>';
+		print '<li>' . __('use "Share this dashboard" option in Actions menu - Every user can use it as template.', 'intropage') . '</li>';
 		print '</ul><br/>';
 		print '</td></tr>';
 
 		print '<tr class="tableRow">';
 		print '<td class="textAreaNotes top left">' . __('You can use shared dashboard using the Actions menu:', 'intropage');
 		print '<ul>';
-		print '<li>' . __('Use "Use shared dashboard (user/dashboard name) -  It prepares the same dashboard like shared but with your permissions.') . '</li>';
+		print '<li>' . __('Use "Use shared dashboard (user/dashboard name) -  It prepares the same dashboard like shared but with your permissions.', 'intropage') . '</li>';
 		print '</ul><br/>';
 		print '</td></tr>';
 
 		print '<tr class="tableRow">';
 		print '<td class="textAreaNotes top left">' . __('Customization:', 'intropage');
 		print '<ul>';
-		print '<li>' . __('You can create up to 9 dashboards. Every dashboard can be named, use icon') . '<i class="intro_glyph fa fa-cog"></i></li>';
-		print '<li>' . __('Intopage can be displayed in console or in separated tab. You can change it in Action menu') . '</li>';
-		print '<li>' . __('If you want to copy text from panel, you have to disable drag and drop function, use icon') . '<i class="intro_glyph fa fa-clone"></i></li>';
+		print '<li>' . __('You can create up to 9 dashboards. Every dashboard can be named, use icon', 'intropage') . '<i class="intro_glyph fa fa-cog"></i></li>';
+		print '<li>' . __('Intopage can be displayed in console or in separated tab. You can change it in Action menu', 'intropage') . '</li>';
+		print '<li>' . __('If you want to copy text from panel, you have to disable drag and drop function, use icon', 'intropage') . '<i class="intro_glyph fa fa-clone"></i></li>';
 		print '</ul><br/>';
 		print '</td></tr>';
 

--- a/include/functions.php
+++ b/include/functions.php
@@ -337,7 +337,7 @@ function intropage_actions() {
 				}
 
 				if ($_SESSION['sess_current_timespan'] == 0) {
-					raise_message('custom_error',__('Cannot add zoomed or custom timespaned graph, changing timespan to Last half hour'));
+					raise_message('custom_error',__('Cannot add zoomed or custom timespaned graph, changing timespan to Last half hour', 'intropage'));
 					$span = 1;
 				} else {
 					$span = $_SESSION['sess_current_timespan'];
@@ -842,7 +842,7 @@ function intropage_reload_panel() {
 		}
 	} else {
 		print '<div class="panel_header color_grey">';
-		print '<div class="panel_name">' . __('Panel not found') . '</div>';
+		print '<div class="panel_name">' . __('Panel not found', 'intropage') . '</div>';
 
 		printf("<div class='panel_actions'></div>");
 		print '</div>'; // end of header
@@ -853,7 +853,7 @@ function intropage_reload_panel() {
 				print maint();
 			}
 		} else {
-			print __('Panel not found');
+			print __('Panel not found', 'intropage');
 		}
 	}
 
@@ -897,7 +897,7 @@ function intropage_detail_panel() {
 		print '</div>';
 		print $data['detail'];
 	} else {
-		print __('Panel Not Found');
+		print __('Panel Not Found', 'intropage');
 	}
 
 	exit;

--- a/panellib/analyze.php
+++ b/panellib/analyze.php
@@ -432,7 +432,7 @@ function analyse_db($panel, $user_id) {
 
 	if ($size > 1073741824) {
 		$panel['alarm'] = 'grey';
-		$panel['data']  = '<tr><td>' . __('Skipping DB tables checks. Database too large') . '</td></tr>';
+		$panel['data']  = '<tr><td>' . __('Skipping DB tables checks. Database too large', 'intropage') . '</td></tr>';
 	} else {
 		$db_check_level = read_config_option('intropage_analyse_db_level');
 
@@ -531,7 +531,7 @@ function analyse_db($panel, $user_id) {
 	$panel['data'] .= '<tr><td>' . __('Damaged tables: %s', $damaged, 'intropage');
 
 	if ($damaged > 0) {
-		$panel['data'] .= display_tooltip(__('You should run check and repair table commands'));
+		$panel['data'] .= display_tooltip(__('You should run check and repair table commands', 'intropage'));
 	}
 
 	$panel['data'] .= '</td></tr>' .
@@ -619,15 +619,15 @@ function analyse_tree_host_graph($panel, $user_id) {
 			}
 
 			$panel['data'] .= '<tr><td class="block"><span class="inpa_sq color_' . $color . '"></span>' . __('Not optimized Bulk Walk Size devices: %s', $count, 'intropage');
-			$panel['data'] .= display_tooltip(__('Please have a look to device parameter "Bulk Walk Maximum Repetitions". You can improve your poller performance')) . '</td></tr>';
+			$panel['data'] .= display_tooltip(__('Please have a look to device parameter "Bulk Walk Maximum Repetitions". You can improve your poller performance', 'intropage')) . '</td></tr>';
 		}
 	}
 
 	// last run of reindex, rrdchecker, ...
 	$last_runs =  [
-		'reindex_last_run_time'    => __('Reindex last run'),
-		'rrdcheck_last_run_time'   => __('RRD Checker last run'),
-		'rrdcleaner_last_run_time' => __('RRD Cleaner last run')
+		'reindex_last_run_time'    => __('Reindex last run', 'intropage'),
+		'rrdcheck_last_run_time'   => __('RRD Checker last run', 'intropage'),
+		'rrdcleaner_last_run_time' => __('RRD Cleaner last run', 'intropage')
 	];
 
 	$date_fmt = date_time_format();
@@ -1011,7 +1011,7 @@ function analyse_tree_host_graph($panel, $user_id) {
 
 	$sett  = db_fetch_row('SELECT processes, threads FROM poller WHERE id = 1');
 	$color = 'green';
-	$text  = __('OK');
+	$text  = __('OK', 'intropage');
 
 	if ($cpu_cores == 0) {
 		if ($sett['processes'] == 1 || $sett['threads'] == 1) {
@@ -1525,7 +1525,7 @@ function analyse_tree_host_graph_detail() {
 		$panel['detail'] .= '<h4>' . __('Not optimized Bulk Walk Size devices - %s', $sql_count, 'intropage') . '<span class="inpa_sq color_' . $color . '"></span>';
 
 		if ($sql_count > 0) {
-			$panel['detail'] .= display_tooltip(__('Please have a look to device parameter "Bulk Walk Maximum Repetitions". You can improve your poller performance')) . '<br/>';
+			$panel['detail'] .= display_tooltip(__('Please have a look to device parameter "Bulk Walk Maximum Repetitions". You can improve your poller performance', 'intropage')) . '<br/>';
 		}
 
 		$panel['detail'] .= '</h4>';
@@ -1547,9 +1547,9 @@ function analyse_tree_host_graph_detail() {
 
 	// last run of reindex, rrdchecker, ...
 	$last_runs =  [
-		'reindex_last_run_time'    => __('Reindex last run'),
-		'rrdcheck_last_run_time'   => __('RRD Checker last run'),
-		'rrdcleaner_last_run_time' => __('RRD Cleaner last run')
+		'reindex_last_run_time'    => __('Reindex last run', 'intropage'),
+		'rrdcheck_last_run_time'   => __('RRD Checker last run', 'intropage'),
+		'rrdcleaner_last_run_time' => __('RRD Cleaner last run', 'intropage')
 	];
 
 	$date_fmt = date_time_format();
@@ -2029,7 +2029,7 @@ function analyse_tree_host_graph_detail() {
 
 	$sett  = db_fetch_row('SELECT processes, threads FROM poller WHERE id = 1');
 	$color = 'green';
-	$text  = __('OK');
+	$text  = __('OK', 'intropage');
 
 	if ($cpu_cores == 0) {
 		if ($sett['processes'] == 1 || $sett['threads'] == 1) {

--- a/panellib/busiest.php
+++ b/panellib/busiest.php
@@ -269,7 +269,7 @@ function busiest_cpu($panel, $user_id) {
 				$i++;
 			}
 
-			$panel['data'] .= '<tr class="odd"><td>' . __('Average of all allowed DS') . '</td><td class="right" colspan="2">' . round($avg, 2) . ' %</td></tr>';
+			$panel['data'] .= '<tr class="odd"><td>' . __('Average of all allowed DS', 'intropage') . '</td><td class="right" colspan="2">' . round($avg, 2) . ' %</td></tr>';
 			$panel['data'] .= '</table>';
 		} else {
 			$panel['data'] = __('Waiting for data or you don\'t have permission for any device with this template.', 'intropage');
@@ -377,7 +377,7 @@ function busiest_load($panel, $user_id) {
 				$i++;
 			}
 
-			$panel['data'] .= '<tr class="odd"><td>' . __('Average of all allowed DS') . '</td><td class="right" colspan="2">' . round($avg, 2) . '</td></tr>';
+			$panel['data'] .= '<tr class="odd"><td>' . __('Average of all allowed DS', 'intropage') . '</td><td class="right" colspan="2">' . round($avg, 2) . '</td></tr>';
 			$panel['data'] .= '</table>';
 		} else {
 			$panel['data'] = __('Waiting for data or you don\'t have permission for any device with this template.', 'intropage');
@@ -518,7 +518,7 @@ function busiest_hdd($panel, $user_id) {
 				$i++;
 			}
 
-			$panel['data'] .= '<tr class="odd"><td>' . __('Average of all allowed DS') . '</td><td class="right" colspan="2">' . round($avg, 2) . ' %</td></tr>';
+			$panel['data'] .= '<tr class="odd"><td>' . __('Average of all allowed DS', 'intropage') . '</td><td class="right" colspan="2">' . round($avg, 2) . ' %</td></tr>';
 			$panel['data'] .= '</table>';
 		} else {
 			$panel['data'] = __('Waiting for data or you don\'t have permission for any device with this template.', 'intropage');
@@ -587,7 +587,7 @@ function busiest_uptime($panel, $user_id) {
 				$i++;
 			}
 
-			$panel['data'] .= '<tr class="odd"><td>' . __('Average of all allowed hosts') . '</td><td class="right">' . get_daysfromtime($avg / 100) . '</td></tr>';
+			$panel['data'] .= '<tr class="odd"><td>' . __('Average of all allowed hosts', 'intropage') . '</td><td class="right">' . get_daysfromtime($avg / 100) . '</td></tr>';
 			$panel['data'] .= '</table>';
 		} else {
 			$panel['data'] = __('Waiting for data or you don\'t have permission for any device', 'intropage');
@@ -722,7 +722,7 @@ function busiest_traffic($panel, $user_id) {
 				$avg *= 8;
 			}
 
-			$panel['data'] .= '<tr class="odd"><td>' . __('Average of all allowed DS') . '</td><td class="right" colspan="2">' . human_readable($avg, false,1) . $units . '</td></tr>';
+			$panel['data'] .= '<tr class="odd"><td>' . __('Average of all allowed DS', 'intropage') . '</td><td class="right" colspan="2">' . human_readable($avg, false,1) . $units . '</td></tr>';
 			$panel['data'] .= '</table>';
 		} else {
 			$panel['data'] = __('Waiting for data or you don\'t have permission for any device with this template.', 'intropage');
@@ -838,7 +838,7 @@ function busiest_interface_error($panel, $user_id) {
 				$i++;
 			}
 
-			$panel['data'] .= '<tr class="odd"><td>' . __('Average of all allowed DS') . '</td><td class="right" colspan="2">' . human_readable($avg) . ' Err/Discard</td></tr>';
+			$panel['data'] .= '<tr class="odd"><td>' . __('Average of all allowed DS', 'intropage') . '</td><td class="right" colspan="2">' . human_readable($avg) . ' Err/Discard</td></tr>';
 			$panel['data'] .= '</table>';
 		} else {
 			$panel['data'] = __('Waiting for data or you don\'t have permission for any device with this template.', 'intropage');
@@ -965,7 +965,7 @@ function busiest_interface_util($panel, $user_id) {
 				}
 			}
 
-			$panel['data'] .= '<tr><td colspan="2">' . __('Time interval last 5 minutes') . '</td></tr>';
+			$panel['data'] .= '<tr><td colspan="2">' . __('Time interval last 5 minutes', 'intropage') . '</td></tr>';
 			$panel['data'] .= '</table>';
 		} else {
 			$panel['data'] = __('Waiting for data or you don\'t have permission for any device with this template.', 'intropage');
@@ -1077,9 +1077,9 @@ function busiest_cpu_detail() {
 				$i++;
 			}
 
-			$panel['detail'] .= '<tr class="odd"><td>' . __('Average of all allowed DS') . '</td><td class="right" colspan="2">' . round($avg, 2) . ' %</td></tr>';
+			$panel['detail'] .= '<tr class="odd"><td>' . __('Average of all allowed DS', 'intropage') . '</td><td class="right" colspan="2">' . round($avg, 2) . ' %</td></tr>';
 			$panel['detail'] .= '</table><br/>';
-			$panel['detail'] .= __('Install TopX plugin for more DS statistics');
+			$panel['detail'] .= __('Install TopX plugin for more DS statistics', 'intropage');
 		} else {
 			$panel['detail'] = __('Waiting for data or you don\'t have permission for any device with this template.', 'intropage');
 		}
@@ -1190,9 +1190,9 @@ function busiest_load_detail() {
 				$i++;
 			}
 
-			$panel['detail'] .= '<tr class="odd"><td>' . __('Average of all allowed DS') . '</td><td class="right" colspan="2">' . round($avg, 2) . '</td></tr>';
+			$panel['detail'] .= '<tr class="odd"><td>' . __('Average of all allowed DS', 'intropage') . '</td><td class="right" colspan="2">' . round($avg, 2) . '</td></tr>';
 			$panel['detail'] .= '</table><br/>';
-			$panel['detail'] .= __('Install TopX plugin for more DS statistics');
+			$panel['detail'] .= __('Install TopX plugin for more DS statistics', 'intropage');
 		} else {
 			$panel['detail'] = __('Waiting for data or you don\'t have permission for any device with this template.', 'intropage');
 		}
@@ -1327,9 +1327,9 @@ function busiest_hdd_detail() {
 				$i++;
 			}
 
-			$panel['detail'] .= '<tr class="odd"><td>' . __('Average of all allowed DS') . '</td><td class="right" colspan="2">' . round($avg, 2) . ' %</td></tr>';
+			$panel['detail'] .= '<tr class="odd"><td>' . __('Average of all allowed DS', 'intropage') . '</td><td class="right" colspan="2">' . round($avg, 2) . ' %</td></tr>';
 			$panel['detail'] .= '</table><br/>';
-			$panel['detail'] .= __('Install TopX plugin for more DS statistics');
+			$panel['detail'] .= __('Install TopX plugin for more DS statistics', 'intropage');
 		} else {
 			$panel['detail'] = __('Waiting for data or you don\'t have permission for any device with this template.', 'intropage');
 		}
@@ -1400,7 +1400,7 @@ function busiest_uptime_detail() {
 				$i++;
 			}
 
-			$panel['detail'] .= '<tr class="odd"><td>' . __('Average of all allowed hosts') . '</td><td class="right">' . get_daysfromtime($avg / 100) . '</td></tr>';
+			$panel['detail'] .= '<tr class="odd"><td>' . __('Average of all allowed hosts', 'intropage') . '</td><td class="right">' . get_daysfromtime($avg / 100) . '</td></tr>';
 			$panel['detail'] .= '</table>';
 		} else {
 			$panel['detail'] = __('Waiting for data or you don\'t have permission for any device', 'intropage');
@@ -1539,7 +1539,7 @@ function busiest_traffic_detail() {
 				$avg *= 8;
 			}
 
-			$panel['detail'] .= '<tr class="odd"><td>' . __('Average of all allowed DS') . '</td><td class="right" colspan="2">' . human_readable($avg, false) . $units . '</td></tr>';
+			$panel['detail'] .= '<tr class="odd"><td>' . __('Average of all allowed DS', 'intropage') . '</td><td class="right" colspan="2">' . human_readable($avg, false) . $units . '</td></tr>';
 			$panel['detail'] .= '</table>';
 		} else {
 			$panel['detail'] = __('Waiting for data or you don\'t have permission for any device with this template.', 'intropage');
@@ -1658,7 +1658,7 @@ function busiest_interface_error_detail() {
 				$i++;
 			}
 
-			$panel['detail'] .= '<tr class="odd"><td>' . __('Average of all allowed DS') . '</td><td class="right" colspan="2">' . human_readable($avg) . ' Err/Discard</td></tr>';
+			$panel['detail'] .= '<tr class="odd"><td>' . __('Average of all allowed DS', 'intropage') . '</td><td class="right" colspan="2">' . human_readable($avg) . ' Err/Discard</td></tr>';
 			$panel['detail'] .= '</table>';
 		} else {
 			$panel['detail'] = __('Waiting for data or you don\'t have permission for any device with this template.', 'intropage');

--- a/panellib/graphs.php
+++ b/panellib/graphs.php
@@ -416,7 +416,7 @@ function graph_data_source_detail() {
 	if (cacti_sizeof($sql_ds)) {
 		$panel['detail'] .= '<tr class="tableHeader">
 			<th class="left">' . __('Data Type', 'intropage') . '</th>
-			<th class="right">' . __('Data Sources') . '</th>
+			<th class="right">' . __('Data Sources', 'intropage') . '</th>
 		</tr>';
 
 		$i = 0;
@@ -438,7 +438,7 @@ function graph_data_source_detail() {
 
 		$panel['detail'] .= '</table>';
 	} else {
-		$panel['detail'] = __('No untemplated datasources found');
+		$panel['detail'] = __('No untemplated datasources found', 'intropage');
 	}
 
 	return $panel;

--- a/panellib/misc.php
+++ b/panellib/misc.php
@@ -365,12 +365,12 @@ function webseer($panel, $user_id) {
 					if ($row['secs'] > (time() - ($important_period))) {
 						$color = 'green';
 					}
-					$text = __('OK');
+					$text = __('OK', 'intropage');
 				} else {
 					if ($row['secs'] > (time() - ($important_period))) {
 						$color = 'red';
 					}
-					$text = __('Failed');
+					$text = __('Failed', 'intropage');
 				}
 
 				if ($panel['alarm'] == 'grey' && $color == 'green') {
@@ -443,12 +443,12 @@ function webseer_detail() {
 			if ($log['secs'] > (time() - ($important_period))) {
 				$color = 'green';
 			}
-			$panel['detail'] .= '<td class="left"><span class="inpa_sq color_' . $color . '"></span>' . __('OK') . '</td>';
+			$panel['detail'] .= '<td class="left"><span class="inpa_sq color_' . $color . '"></span>' . __('OK', 'intropage') . '</td>';
 		} else {
 			if ($log['secs'] > (time() - ($important_period))) {
 				$color = 'red';
 			}
-			$panel['detail'] .= '<td class="left"><span class="inpa_sq color_' . $color . '"></span>' . __('Failed') . '</td>';
+			$panel['detail'] .= '<td class="left"><span class="inpa_sq color_' . $color . '"></span>' . __('Failed', 'intropage') . '</td>';
 		}
 
 		$panel['detail'] .= '<td class="right">' . $log['http_code'] . '</td>';
@@ -549,12 +549,12 @@ function servcheck($panel, $user_id) {
 					if ($row['secs'] > (time() - ($important_period))) {
 						$color = 'green';
 					}
-					$text = __('OK');
+					$text = __('OK', 'intropage');
 				} else {
 					if ($row['secs'] > (time() - ($important_period))) {
 						$color = 'red';
 					}
-					$text = __('Failed');
+					$text = __('Failed', 'intropage');
 				}
 
 				if ($panel['alarm'] == 'grey' && $color == 'green') {
@@ -646,12 +646,12 @@ function servcheck_detail() {
 				$color = 'green';
 			}
 
-			$panel['detail'] .= '<td class="left"><span class="inpa_sq color_' . $color . '"></span>' . __('OK') . '</td>';
+			$panel['detail'] .= '<td class="left"><span class="inpa_sq color_' . $color . '"></span>' . __('OK', 'intropage') . '</td>';
 		} else {
 			if ($log['secs'] > (time() - ($important_period))) {
 				$color = 'red';
 			}
-			$panel['detail'] .= '<td class="left"><span class="inpa_sq color_' . $color . '"></span>' . __('Failed') . '</td>';
+			$panel['detail'] .= '<td class="left"><span class="inpa_sq color_' . $color . '"></span>' . __('Failed', 'intropage') . '</td>';
 		}
 
 		$panel['detail'] .= '<td class="right">' . $log['result_search'] . '</td>';

--- a/panellib/system.php
+++ b/panellib/system.php
@@ -473,7 +473,7 @@ function boost($panel, $user_id) {
 			$boost_status_text = __('Timed Out', 'intropage');
 			$panel['alarm']    = 'red';
 		} else {
-			$boost_status_text = __('Other');
+			$boost_status_text = __('Other', 'intropage');
 		}
 	} else {
 		$boost_status_text = __('Never Run', 'intropage');
@@ -501,7 +501,7 @@ function boost($panel, $user_id) {
 
 	$panel['data'] .= '<tr><td><hr></td></tr>';
 
-	$panel['data'] .= '<tr><td>' . __('Processes/Frequency: %s / %s', number_format_i18n($parallel, -1), $rrd_updates == '' ? __('N/A') : $boost_refresh_interval[$update_int], 'intropage') . '</td></tr>';
+	$panel['data'] .= '<tr><td>' . __('Processes/Frequency: %s / %s', number_format_i18n($parallel, -1), $rrd_updates == '' ? __('N/A', 'intropage') : $boost_refresh_interval[$update_int], 'intropage') . '</td></tr>';
 
 	$panel['data'] .= '<tr><td>' . __('Pending Records Threshold: %s', number_format_i18n($max_records, -1), 'intropage') . '</td></tr>';
 
@@ -534,7 +534,7 @@ function boost($panel, $user_id) {
 	if (is_numeric($boost_last_run_duration)) {
 		$lastduration = $boost_last_run_duration . ' s';
 	} else {
-		$lastduration = __('N/A');
+		$lastduration = __('N/A', 'intropage');
 	}
 
 	$panel['data'] .= '<tr><td><hr></td></tr>';

--- a/setup.php
+++ b/setup.php
@@ -78,6 +78,10 @@ function plugin_intropage_uninstall() {
 function intropage_config_arrays() {
 	global $intropage_intervals, $trend_timespans, $panel_lines;
 
+	// Core builds $user_auth_roles with __('Normal User') in the core domain
+	// (include/global_arrays.php), and auth_augment_roles() indexes by that
+	// exact string. Adding the intropage domain here would key a new role on
+	// translated installs and silently drop the realm.
 	auth_augment_roles(__('Normal User'), ['intropage.php']);
 	auth_augment_roles(__('System Administration'), ['intropage_admin.php']);
 


### PR DESCRIPTION
`locales/po` ships translations for these strings in every supported language, and none of them ever displayed.

Cacti resolves `__('text')` against the core catalog and `__('text', 'intropage')` against the plugin's own. 921 call sites in this plugin already pass the domain. 51 did not, so those strings fell through to the core catalog, missed, and rendered in English regardless of the user's locale.

The German catalog is the clearest proof. `locales/po/de-DE.po` carries:

```
msgid "Select prepared panels from the \"Panels menu\". ..."
msgstr "Wählen Sie vorbereitete Paneele aus dem \"Menü Paneele\" aus. ..."
```

while `display.php` asked for it without the domain, so a German user saw the English line.

Affected: `display.php`, `include/functions.php`, `panellib/analyze.php`, `panellib/busiest.php`, `panellib/graphs.php`, `panellib/misc.php`, `panellib/system.php`.

**The `auth_augment_roles()` role names deliberately keep the core domain.** Core builds `$user_auth_roles` with `__('Normal User')` and `__('System Administration')` in the core catalog (`include/global_arrays.php:1266`), and `auth_augment_roles()` indexes that array by the exact string. Passing the plugin domain there would produce a different string on any translated install, key a role that does not exist, and silently fail to attach `intropage.php` and `intropage_admin.php` to the real roles. I made that mistake in the first draft of this branch; there is now a comment at the call site so it does not get "fixed" again.

Verification:

```
before   921 calls with the domain, 54 single-arg without, 0 multi-arg without
after    921 with the domain, 4 core-domain role lookups, 0 unintended
role calls  unchanged, and commented
php -l   clean across all 28 runtime files
```

No behavior change for an English install.
