### PR TITLE
fix: validate the three values that reach SQL as text

### DIFF
--- a/include/database.php
+++ b/include/database.php
@@ -248,7 +248,16 @@ function intropage_upgrade_database() {
 						case 'permissions':
 							break;
 						default:
-							db_execute('ALTER TABLE plugin_intropage_user_auth DROP COLUMN ' . $c['Field']);
+							// db_is_safe_identifier() postdates the 1.2.17 baseline in INFO.
+							$safe = function_exists('db_is_safe_identifier')
+								? db_is_safe_identifier($c['Field'])
+								: preg_match('/^[A-Za-z0-9_]+$/', (string) $c['Field']) === 1;
+
+							if ($safe) {
+								db_execute('ALTER TABLE plugin_intropage_user_auth DROP COLUMN `' . $c['Field'] . '`');
+							} else {
+								cacti_log('WARNING: intropage refused to drop column with an unexpected name', false, 'INTROPAGE');
+							}
 
 							break;
 					}

--- a/include/functions.php
+++ b/include/functions.php
@@ -129,6 +129,10 @@ function intropage_action_settings() {
 		if (strpos($var, 'name_') !== false) {
 			$dashboard_id = str_replace('name_', '', $var);
 
+			if (!is_numeric($dashboard_id)) {
+				continue;
+			}
+
 			db_execute_prepared('REPLACE INTO plugin_intropage_dashboard
 				(user_id, dashboard_id, name)
 				VALUES (?, ?, ?)',

--- a/include/functions.php
+++ b/include/functions.php
@@ -124,12 +124,27 @@ function intropage_action_add_panel() {
 	}
 }
 
+function intropage_parse_dashboard_id($value) {
+	if (!is_string($value) || preg_match('/\A(?:0|[1-9][0-9]*)\z/D', $value) !== 1) {
+		return null;
+	}
+
+	$id = filter_var($value, FILTER_VALIDATE_INT, [
+		'options' => [
+			'min_range' => 0,
+			'max_range' => 2147483647,
+		],
+	]);
+
+	return $id === false ? null : $id;
+}
+
 function intropage_action_settings() {
 	foreach ($_POST as $var => $value) {
 		if (strpos($var, 'name_') !== false) {
-			$dashboard_id = str_replace('name_', '', $var);
+			$dashboard_id = intropage_parse_dashboard_id(str_replace('name_', '', $var));
 
-			if (!is_numeric($dashboard_id)) {
+			if ($dashboard_id === null) {
 				continue;
 			}
 

--- a/panellib/analyze.php
+++ b/panellib/analyze.php
@@ -436,6 +436,12 @@ function analyse_db($panel, $user_id) {
 	} else {
 		$db_check_level = read_config_option('intropage_analyse_db_level');
 
+		// The setting is a drop_array, but it reaches SQL as text; keep the
+		// allowed list authoritative here too. See include/variables.php.
+		if (!in_array($db_check_level, ['QUICK', 'FAST', 'CHANGED', 'MEDIUM', 'EXTENDED'], true)) {
+			$db_check_level = 'CHANGED';
+		}
+
 		foreach ($tables as $key => $val) {
 			$row = db_fetch_row('check table ' . current($val) . ' ' . $db_check_level);
 

--- a/tests/Security/DashboardIdValidationTest.php
+++ b/tests/Security/DashboardIdValidationTest.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once __DIR__ . '/../../include/functions.php';
+
+describe('dashboard identifier validation', function () {
+	it('returns canonical database integers', function () {
+		expect(intropage_parse_dashboard_id('0'))->toBe(0)
+			->and(intropage_parse_dashboard_id('42'))->toBe(42)
+			->and(intropage_parse_dashboard_id('2147483647'))->toBe(2147483647);
+	});
+
+	it('rejects numeric strings that MySQL would coerce', function ($value) {
+		expect(intropage_parse_dashboard_id($value))->toBeNull();
+	})->with([
+		'scientific notation' => '1e3',
+		'leading plus'        => '+3',
+		'trailing whitespace' => '3 ',
+		'decimal'             => '3.14',
+		'leading zero'        => '03',
+		'negative'            => '-1',
+		'out of range'        => '2147483648',
+		'empty'               => '',
+	]);
+});


### PR DESCRIPTION
A SQL review of the plugin found no injection. Every request-carried value reaches the database through a prepared statement, and the ~99 dynamic queries resolve to literals, integer primary keys, or `db_qstr()`.

Three values reach SQL as text rather than as a bound parameter. None is request-reachable today, so this is defence in depth, not a fix for a live bug. Each guard sits at the point of use so it holds regardless of how the value got there.

**`include/database.php`** interpolated a column name into `ALTER TABLE ... DROP COLUMN` unquoted. The name comes from `SHOW COLUMNS`, but the columns themselves are created from panel ids via `api_plugin_db_add_column()`, so the value is only as constrained as that path stays. It is now validated and backtick-quoted, and a rejected name is logged instead of executed.

Core's `db_is_safe_identifier()` is the right helper, but it postdates the `compat = 1.2.17` this plugin declares (added in Cacti/cacti#7235), so it is called through `function_exists()` with an inline fallback. The plugin already uses that pattern for `auth_augment_roles()`.

**`panellib/analyze.php`** put `read_config_option('intropage_analyse_db_level')` straight into `check table ... <level>`. It is a `drop_array` over five constants in `include/variables.php`, so the form constrains it, but the value is read back as text. The allowed list is now authoritative at the point of use, with `CHANGED` as the fallback.

**`include/functions.php`** derived `$dashboard_id` from a `$_POST` key via `str_replace('name_', '', $var)`. It was already bound, so there was no injection, but any string could become a dashboard id. Non-numeric keys are now skipped.

Behaviour:

```
ident 'panel_system'                accepted
ident 'a`b'                         rejected
ident 'x; DROP TABLE y'             rejected
level 'EXTENDED'                 -> EXTENDED
level 'EXTENDED; DROP TABLE host'-> CHANGED (fallback)
dashboard '3'                       processed
dashboard '1 OR 1=1'                skipped
```

`php -l` clean on all three files. No behaviour change for valid input.

Checked against the other open PRs before writing this: #373 and #374 touch two of the same files but not these lines, and #367's `include/database.php` change is a blank-line removal.
