### PR TITLE
refactor: extract intropage_device_scope() and add a coverage harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 
 locales/po/*.mo
+
+.phpunit.cache/
+.php-cs-fixer.cache

--- a/include/functions.php
+++ b/include/functions.php
@@ -52,6 +52,31 @@ function intropage_get_allowed_devices($user_id) {
 	}
 }
 
+/**
+ * Resolve a user's device-visibility scope for panel queries.
+ *
+ * Panels restrict their host queries to the devices a user may see. A user with
+ * simple device permissions can see every device, so no host filter is needed;
+ * otherwise the panel constrains its query to the allowed host ids. This wraps
+ * the two-call permission preamble the panels would otherwise repeat. The
+ * caller formats its own IN() clause from 'allowed', because the column and any
+ * "AND" prefix differ between panels.
+ *
+ * @param int|string $user_id Cacti user id whose permissions to resolve.
+ *
+ * @return array{simple: bool, allowed: string|false}
+ *                                                    simple  - true when the user sees every device (no filter needed).
+ *                                                    allowed - comma-separated allowed host ids, or false when the user is
+ *                                                    simple or has no visible devices.
+ */
+function intropage_device_scope($user_id): array {
+	if (get_simple_device_perms($user_id)) {
+		return ['simple' => true, 'allowed' => false];
+	}
+
+	return ['simple' => false, 'allowed' => intropage_get_allowed_devices($user_id)];
+}
+
 function process_page_request_variables() {
 	set_default_action();
 

--- a/panellib/alert.php
+++ b/panellib/alert.php
@@ -70,15 +70,10 @@ function alert_host($panel, $user_id) {
 
 	$panel['alarm'] = 'green';
 
-	$simple_perms = get_simple_device_perms($user_id);
-
-	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($user_id);
-		$host_cond       = 'AND host.id IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$host_cond       = '';
-	}
+	$scope           = intropage_device_scope($user_id);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$host_cond       = $simple_perms ? '' : 'AND host.id IN (' . $allowed_devices . ')';
 
 	if ($allowed_devices !== false || $simple_perms) {
 		$console_access = get_console_access($user_id);
@@ -212,15 +207,10 @@ function alert_host_detail() {
 
 	$lines = 20;
 
-	$simple_perms = get_simple_device_perms($_SESSION['sess_user_id']);
-
-	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($_SESSION['sess_user_id']);
-		$host_cond       = 'AND host.id IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$host_cond       = '';
-	}
+	$scope           = intropage_device_scope($_SESSION['sess_user_id']);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$host_cond       = $simple_perms ? '' : 'AND host.id IN (' . $allowed_devices . ')';
 
 	if ($allowed_devices !== false || $simple_perms) {
 		$console_access = get_console_access($_SESSION['sess_user_id']);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+	cacheDirectory=".phpunit.cache">
+	<testsuites>
+		<testsuite name="intropage">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
+	<source>
+		<include>
+			<directory suffix=".php">include</directory>
+			<directory suffix=".php">panellib</directory>
+			<file>display.php</file>
+			<file>setup.php</file>
+			<file>poller_intropage.php</file>
+		</include>
+	</source>
+</phpunit>

--- a/tests/Unit/DeviceScopeTest.php
+++ b/tests/Unit/DeviceScopeTest.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once __DIR__ . '/../../include/functions.php';
+
+describe('intropage_device_scope', function () {
+	afterEach(function () {
+		unset($GLOBALS['__test_simple_perms'], $GLOBALS['__test_allowed_devices']);
+	});
+
+	it('returns a see-all scope for a simple-permission user', function () {
+		$GLOBALS['__test_simple_perms'] = true;
+
+		$scope = intropage_device_scope(1);
+
+		expect($scope['simple'])->toBeTrue();
+		expect($scope['allowed'])->toBeFalse();
+	});
+
+	it('returns the allowed host ids for a restricted user', function () {
+		$GLOBALS['__test_simple_perms']    = false;
+		$GLOBALS['__test_allowed_devices'] = [['id' => 3], ['id' => 7], ['id' => 9]];
+
+		$scope = intropage_device_scope(2);
+
+		expect($scope['simple'])->toBeFalse();
+		expect($scope['allowed'])->toBe('3,7,9');
+	});
+
+	it('returns allowed=false for a restricted user with no visible devices', function () {
+		$GLOBALS['__test_simple_perms']    = false;
+		$GLOBALS['__test_allowed_devices'] = [];
+
+		$scope = intropage_device_scope(2);
+
+		expect($scope['simple'])->toBeFalse();
+		expect($scope['allowed'])->toBeFalse();
+	});
+});

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -195,3 +195,35 @@ if (!defined('POLLER_VERBOSITY_NONE')) {
 if (!defined('MESSAGE_LEVEL_ERROR')) {
 	define('MESSAGE_LEVEL_ERROR', 1);
 }
+
+// Test-controllable stubs for the device-permission chain used by
+// intropage_device_scope() / intropage_get_allowed_devices().
+if (!function_exists('get_simple_device_perms')) {
+	function get_simple_device_perms($user_id) {
+		return $GLOBALS['__test_simple_perms'] ?? false;
+	}
+}
+
+if (!function_exists('read_user_setting')) {
+	function read_user_setting($name, $default = false, $force = false, $user_id = 0) {
+		return $default;
+	}
+}
+
+if (!function_exists('set_user_setting')) {
+	function set_user_setting($name, $value, $user_id = 0) {
+		return true;
+	}
+}
+
+if (!function_exists('get_allowed_devices')) {
+	function get_allowed_devices($sql_where, $order, $limit, &$total, $user_id) {
+		return $GLOBALS['__test_allowed_devices'] ?? [];
+	}
+}
+
+if (!function_exists('cacti_count')) {
+	function cacti_count($a) {
+		return is_array($a) ? count($a) : 0;
+	}
+}


### PR DESCRIPTION
First increment of the panel de-duplication, plus the test infrastructure it needs.

## Helper
The device-permission preamble (`get_simple_device_perms` then, for non-simple users, `intropage_get_allowed_devices`) is copied ~39 times across the panels. This adds one documented `intropage_device_scope($user_id)` returning `{simple, allowed}` and adopts it in the two `alert.php` panels (an 8-line block becomes 4, behaviour identical). It returns only the uniform parts: the IN() clause is left to the caller because the column and any `AND` prefix differ between panels (for example `alert.php` uses `AND host.id IN (...)`).

## Coverage harness
The plugin had no coverage configuration, and its `tests/Security/*` are source-pattern scans rather than behavioural tests. This adds a `phpunit.xml` with a coverage source list so coverage is measurable, plus `tests/Unit/DeviceScopeTest.php` and permission-chain stubs in `tests/bootstrap.php`. The test drives every branch of the helper (all pass under PHP 8.4).

Note: five `tests/Security/*` cases already fail on `develop` (verified by stashing this change); they are pre-existing and untouched here.

This is deliberately one family. The remaining ~37 sites want per-site verification of each IN()-clause variant, done family by family, not a blind sweep.

Closes #384