### PR TITLE
refactor: add intropage_device_scope() and adopt it across the busiest panels

### DIFF
--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4']
         os: [ubuntu-latest]
     
     services:
@@ -82,7 +82,9 @@ jobs:
       run: php -v
     
     - name: Run apt-get update
-      run: sudo apt-get update
+      run: |
+        sudo add-apt-repository -y ppa:ondrej/php
+        sudo apt-get update
     
     - name: Install System Dependencies
       run: sudo apt-get install -y apache2 snmp snmpd rrdtool fping

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 
 locales/po/*.mo
+
+.phpunit.cache/
+.php-cs-fixer.cache

--- a/include/functions.php
+++ b/include/functions.php
@@ -52,6 +52,31 @@ function intropage_get_allowed_devices($user_id) {
 	}
 }
 
+/**
+ * Resolve a user's device-visibility scope for panel queries.
+ *
+ * Panels restrict their host queries to the devices a user may see. A user with
+ * simple device permissions can see every device, so no host filter is needed;
+ * otherwise the panel constrains its query to the allowed host ids. This wraps
+ * the two-call permission preamble the panels would otherwise repeat. The
+ * caller formats its own IN() clause from 'allowed', because the column and any
+ * "AND" prefix differ between panels.
+ *
+ * @param int|string $user_id Cacti user id whose permissions to resolve.
+ *
+ * @return array{simple: bool, allowed: string|false}
+ *                                                    simple  - true when the user sees every device (no filter needed).
+ *                                                    allowed - comma-separated allowed host ids, or false when the user is
+ *                                                    simple or has no visible devices.
+ */
+function intropage_device_scope($user_id): array {
+	if (get_simple_device_perms($user_id)) {
+		return ['simple' => true, 'allowed' => false];
+	}
+
+	return ['simple' => false, 'allowed' => intropage_get_allowed_devices($user_id)];
+}
+
 function process_page_request_variables() {
 	set_default_action();
 

--- a/panellib/alert.php
+++ b/panellib/alert.php
@@ -70,15 +70,10 @@ function alert_host($panel, $user_id) {
 
 	$panel['alarm'] = 'green';
 
-	$simple_perms = get_simple_device_perms($user_id);
-
-	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($user_id);
-		$host_cond       = 'AND host.id IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$host_cond       = '';
-	}
+	$scope           = intropage_device_scope($user_id);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$host_cond       = $simple_perms ? '' : 'AND host.id IN (' . $allowed_devices . ')';
 
 	if ($allowed_devices !== false || $simple_perms) {
 		$console_access = get_console_access($user_id);
@@ -212,15 +207,10 @@ function alert_host_detail() {
 
 	$lines = 20;
 
-	$simple_perms = get_simple_device_perms($_SESSION['sess_user_id']);
-
-	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($_SESSION['sess_user_id']);
-		$host_cond       = 'AND host.id IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$host_cond       = '';
-	}
+	$scope           = intropage_device_scope($_SESSION['sess_user_id']);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$host_cond       = $simple_perms ? '' : 'AND host.id IN (' . $allowed_devices . ')';
 
 	if ($allowed_devices !== false || $simple_perms) {
 		$console_access = get_console_access($_SESSION['sess_user_id']);

--- a/panellib/busiest.php
+++ b/panellib/busiest.php
@@ -188,14 +188,13 @@ function busiest_cpu($panel, $user_id) {
 		return true;
 	}
 
-	$simple_perms = get_simple_device_perms($user_id);
+	$scope           = intropage_device_scope($user_id);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($user_id);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	$ds = db_fetch_row("SELECT id, name
@@ -305,14 +304,13 @@ function busiest_load($panel, $user_id) {
 		return true;
 	}
 
-	$simple_perms = get_simple_device_perms($user_id);
+	$scope           = intropage_device_scope($user_id);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($user_id);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	$ds = db_fetch_row("SELECT id, name
@@ -413,14 +411,13 @@ function busiest_hdd($panel, $user_id) {
 		return true;
 	}
 
-	$simple_perms = get_simple_device_perms($user_id);
+	$scope           = intropage_device_scope($user_id);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($user_id);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	$ds = db_fetch_row("SELECT id,name
@@ -540,14 +537,13 @@ function busiest_uptime($panel, $user_id) {
 
 	$console_access = get_console_access($user_id);
 
-	$simple_perms = get_simple_device_perms($user_id);
+	$scope           = intropage_device_scope($user_id);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($user_id);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	if ($allowed_devices !== false || $simple_perms) {
@@ -625,14 +621,13 @@ function busiest_traffic($panel, $user_id) {
 		return true;
 	}
 
-	$simple_perms = get_simple_device_perms($user_id);
+	$scope           = intropage_device_scope($user_id);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($user_id);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	$ds = db_fetch_row("SELECT id,name
@@ -758,14 +753,13 @@ function busiest_interface_error($panel, $user_id) {
 		return true;
 	}
 
-	$simple_perms = get_simple_device_perms($user_id);
+	$scope           = intropage_device_scope($user_id);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($user_id);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	$ds = db_fetch_row("SELECT id, name
@@ -876,14 +870,13 @@ function busiest_interface_util($panel, $user_id) {
 		return true;
 	}
 
-	$simple_perms = get_simple_device_perms($user_id);
+	$scope           = intropage_device_scope($user_id);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($user_id);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	$ds = db_fetch_row("SELECT id,name
@@ -1001,14 +994,13 @@ function busiest_cpu_detail() {
 		return ($panel);
 	}
 
-	$simple_perms = get_simple_device_perms($_SESSION['sess_user_id']);
+	$scope           = intropage_device_scope($_SESSION['sess_user_id']);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($_SESSION['sess_user_id']);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	$ds = db_fetch_row("SELECT id, name
@@ -1114,14 +1106,13 @@ function busiest_load_detail() {
 		return ($panel);
 	}
 
-	$simple_perms = get_simple_device_perms($_SESSION['sess_user_id']);
+	$scope           = intropage_device_scope($_SESSION['sess_user_id']);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($_SESSION['sess_user_id']);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	$ds = db_fetch_row("SELECT id,name
@@ -1227,14 +1218,13 @@ function busiest_hdd_detail() {
 		return ($panel);
 	}
 
-	$simple_perms = get_simple_device_perms($_SESSION['sess_user_id']);
+	$scope           = intropage_device_scope($_SESSION['sess_user_id']);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($_SESSION['sess_user_id']);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	$ds = db_fetch_row("SELECT id,name
@@ -1352,14 +1342,13 @@ function busiest_uptime_detail() {
 
 	$console_access = get_console_access($_SESSION['sess_user_id']);
 
-	$simple_perms = get_simple_device_perms($_SESSION['sess_user_id']);
+	$scope           = intropage_device_scope($_SESSION['sess_user_id']);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($_SESSION['sess_user_id']);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	if ($allowed_devices !== false || $simple_perms) {
@@ -1438,14 +1427,13 @@ function busiest_traffic_detail() {
 
 	$intropage_mb = read_user_setting('intropage_mb', read_config_option('intropage_mb'), false, $_SESSION['sess_user_id']);
 
-	$simple_perms = get_simple_device_perms($_SESSION['sess_user_id']);
+	$scope           = intropage_device_scope($_SESSION['sess_user_id']);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($_SESSION['sess_user_id']);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	$ds = db_fetch_row("SELECT id, name
@@ -1575,14 +1563,13 @@ function busiest_interface_error_detail() {
 		return ($panel);
 	}
 
-	$simple_perms = get_simple_device_perms($_SESSION['sess_user_id']);
+	$scope           = intropage_device_scope($_SESSION['sess_user_id']);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($_SESSION['sess_user_id']);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	$ds = db_fetch_row("SELECT id, name
@@ -1696,14 +1683,13 @@ function busiest_interface_util_detail() {
 		return ($panel);
 	}
 
-	$simple_perms = get_simple_device_perms($_SESSION['sess_user_id']);
+	$scope           = intropage_device_scope($_SESSION['sess_user_id']);
+	$simple_perms    = $scope['simple'];
+	$allowed_devices = $scope['allowed'];
+	$q_host_cond     = '';
 
 	if (!$simple_perms) {
-		$allowed_devices = intropage_get_allowed_devices($_SESSION['sess_user_id']);
-		$host_cond       = 'IN (' . $allowed_devices . ')';
-	} else {
-		$allowed_devices = false;
-		$q_host_cond     = '';
+		$host_cond = 'IN (' . $allowed_devices . ')';
 	}
 
 	$ds = db_fetch_row("SELECT id,name

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+	cacheDirectory=".phpunit.cache">
+	<testsuites>
+		<testsuite name="intropage">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
+	<source>
+		<include>
+			<directory suffix=".php">include</directory>
+			<directory suffix=".php">panellib</directory>
+			<file>display.php</file>
+			<file>setup.php</file>
+			<file>poller_intropage.php</file>
+		</include>
+	</source>
+</phpunit>

--- a/tests/Unit/BusiestScopeTest.php
+++ b/tests/Unit/BusiestScopeTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once __DIR__ . '/../../include/functions.php';
+require_once __DIR__ . '/../../panellib/busiest.php';
+
+describe('busiest_cpu device scope', function () {
+	beforeEach(function () {
+		$GLOBALS['__test_db_calls']    = [];
+		$GLOBALS['__test_config']      = ['dsstats_enable' => 'on'];
+		$GLOBALS['__test_fetch_row']   = ['id' => 5, 'name' => 'CPU'];
+		$GLOBALS['__test_fetch_assoc'] = [];
+	});
+
+	afterEach(function () {
+		unset(
+			$GLOBALS['__test_simple_perms'],
+			$GLOBALS['__test_allowed_devices'],
+			$GLOBALS['__test_fetch_row'],
+			$GLOBALS['__test_fetch_assoc'],
+			$GLOBALS['__test_db_calls']
+		);
+	});
+
+	function captured_select_sql(): string {
+		$rows = array_filter($GLOBALS['__test_db_calls'], fn ($c) => $c['fn'] === 'db_fetch_assoc');
+
+		return implode("\n", array_column($rows, 'sql'));
+	}
+
+	it('filters the query to the allowed hosts for a restricted user', function () {
+		$GLOBALS['__test_simple_perms']    = false;
+		$GLOBALS['__test_allowed_devices'] = [['id' => 3], ['id' => 7], ['id' => 9]];
+
+		$panel = ['height' => 'normal', 'id' => 1, 'data' => '', 'alarm' => 'grey'];
+		busiest_cpu($panel, 2);
+
+		expect(captured_select_sql())->toContain('AND dl.host_id IN (3,7,9)');
+	});
+
+	it('applies no host filter for a simple-permission user', function () {
+		$GLOBALS['__test_simple_perms'] = true;
+
+		$panel = ['height' => 'normal', 'id' => 1, 'data' => '', 'alarm' => 'grey'];
+		busiest_cpu($panel, 1);
+
+		expect(captured_select_sql())->not->toContain('dl.host_id IN');
+	});
+});

--- a/tests/Unit/DeviceScopeTest.php
+++ b/tests/Unit/DeviceScopeTest.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once __DIR__ . '/../../include/functions.php';
+
+describe('intropage_device_scope', function () {
+	afterEach(function () {
+		unset($GLOBALS['__test_simple_perms'], $GLOBALS['__test_allowed_devices']);
+	});
+
+	it('returns a see-all scope for a simple-permission user', function () {
+		$GLOBALS['__test_simple_perms'] = true;
+
+		$scope = intropage_device_scope(1);
+
+		expect($scope['simple'])->toBeTrue();
+		expect($scope['allowed'])->toBeFalse();
+	});
+
+	it('returns the allowed host ids for a restricted user', function () {
+		$GLOBALS['__test_simple_perms']    = false;
+		$GLOBALS['__test_allowed_devices'] = [['id' => 3], ['id' => 7], ['id' => 9]];
+
+		$scope = intropage_device_scope(2);
+
+		expect($scope['simple'])->toBeFalse();
+		expect($scope['allowed'])->toBe('3,7,9');
+	});
+
+	it('returns allowed=false for a restricted user with no visible devices', function () {
+		$GLOBALS['__test_simple_perms']    = false;
+		$GLOBALS['__test_allowed_devices'] = [];
+
+		$scope = intropage_device_scope(2);
+
+		expect($scope['simple'])->toBeFalse();
+		expect($scope['allowed'])->toBeFalse();
+	});
+});

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -195,3 +195,35 @@ if (!defined('POLLER_VERBOSITY_NONE')) {
 if (!defined('MESSAGE_LEVEL_ERROR')) {
 	define('MESSAGE_LEVEL_ERROR', 1);
 }
+
+// Test-controllable stubs for the device-permission chain used by
+// intropage_device_scope() / intropage_get_allowed_devices().
+if (!function_exists('get_simple_device_perms')) {
+	function get_simple_device_perms($user_id) {
+		return $GLOBALS['__test_simple_perms'] ?? false;
+	}
+}
+
+if (!function_exists('read_user_setting')) {
+	function read_user_setting($name, $default = false, $force = false, $user_id = 0) {
+		return $default;
+	}
+}
+
+if (!function_exists('set_user_setting')) {
+	function set_user_setting($name, $value, $user_id = 0) {
+		return true;
+	}
+}
+
+if (!function_exists('get_allowed_devices')) {
+	function get_allowed_devices($sql_where, $order, $limit, &$total, $user_id) {
+		return $GLOBALS['__test_allowed_devices'] ?? [];
+	}
+}
+
+if (!function_exists('cacti_count')) {
+	function cacti_count($a) {
+		return is_array($a) ? count($a) : 0;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,7 +27,9 @@ if (!function_exists('db_execute_prepared')) {
 
 if (!function_exists('db_fetch_assoc')) {
 	function db_fetch_assoc($sql) {
-		return [];
+		$GLOBALS['__test_db_calls'][] = ['fn' => 'db_fetch_assoc', 'sql' => $sql, 'params' => []];
+
+		return $GLOBALS['__test_fetch_assoc'] ?? [];
 	}
 }
 
@@ -39,7 +41,7 @@ if (!function_exists('db_fetch_assoc_prepared')) {
 
 if (!function_exists('db_fetch_row')) {
 	function db_fetch_row($sql) {
-		return [];
+		return $GLOBALS['__test_fetch_row'] ?? [];
 	}
 }
 
@@ -87,7 +89,7 @@ if (!function_exists('api_plugin_db_table_create')) {
 
 if (!function_exists('read_config_option')) {
 	function read_config_option($n, $f = false) {
-		return '';
+		return $GLOBALS['__test_config'][$n] ?? $f;
 	}
 }
 


### PR DESCRIPTION
Two commits: the helper plus a coverage harness, then adopting it across the panels that repeat the same device-scope query construction.

Kept together because #378 was fully contained in this branch — reviewing them separately meant reviewing the helper twice.

Supersedes #378.